### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
     "name" : "DispatchMap",
+    "license" : "MIT",
     "perl" : "6.*",
     "version" : "0.2.3",
     "description" : "A map that uses Perl 6 multi dispatch to link keys to values",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license