### PR TITLE
Add support for the latest Rakudo version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ script:
   - prove -v -e 'perl6 -Ilib' t/
 sudo: false
 install:
-  - rakudobrew build-panda
-  - panda installdeps .
+  - rakudobrew build zef
+  - zef install --deps-only .

--- a/lib/DispatchMap.pm6
+++ b/lib/DispatchMap.pm6
@@ -1,5 +1,9 @@
 unit class DispatchMap does Associative;
 
+BEGIN {
+    die "DispatchMap is currenly only works with Rakudo compiler" unless $*RAKU.compiler.name eq 'rakudo';
+}
+
 has $.disp-obj = Metamodel::ClassHOW.new_type();
 has $!dispatcher;
 
@@ -25,7 +29,12 @@ method !add-dispatch($ns,@key,$value) {
         } else {
             $_;
         }
-        nqp::bindattr($param,Parameter,'$!nominal_type',nqp::decont($nominal-type));
+        if $*RAKU.compiler.version >= v2020.10.104.g.1.f.090.e.04.d {
+            nqp::bindattr($param,Parameter,'$!type',nqp::decont($nominal-type));
+        }
+        else {
+            nqp::bindattr($param,Parameter,'$!nominal_type',nqp::decont($nominal-type));
+        }
         nqp::bindattr_i($param,Parameter,'$!flags',128);
         nqp::push($params,$param);
     }

--- a/lib/DispatchMap.pm6
+++ b/lib/DispatchMap.pm6
@@ -1,8 +1,10 @@
 unit class DispatchMap does Associative;
 
 BEGIN {
-    die "DispatchMap is currenly only works with Rakudo compiler" unless $*RAKU.compiler.name eq 'rakudo';
+    die "DispatchMap currenly works with Rakudo compiler only" unless ($*PERL // $*RAKU).compiler.name eq 'rakudo';
 }
+
+constant NEW-PARAM-VERSION = ($*PERL // $*RAKU).compiler.version >= v2020.10.104.g.1.f.090.e.04.d;
 
 has $.disp-obj = Metamodel::ClassHOW.new_type();
 has $!dispatcher;
@@ -29,7 +31,7 @@ method !add-dispatch($ns,@key,$value) {
         } else {
             $_;
         }
-        if $*RAKU.compiler.version >= v2020.10.104.g.1.f.090.e.04.d {
+        if NEW-PARAM-VERSION {
             nqp::bindattr($param,Parameter,'$!type',nqp::decont($nominal-type));
         }
         else {


### PR DESCRIPTION
Since the new coercion semantics merge `Parameter` has only `$!type`
attribute.

Also, added a check for compiler name. Even though we now only have
Rakudo, it's better to take some precautionary measures.